### PR TITLE
fix: ts 2309 multiple exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,15 @@
+declare namespace MovingAverage {
+  export interface IMovingAverage {
+    variance: () => number
+    movingAverage: () => number
 
-export function MovingAverage (timespan:number): MovingAverage
-export interface MovingAverage {
-  variance: () => number
-  movingAverage: () => number
+    deviation: () => number
+    forecast: () => number
 
-  deviation: () => number
-  forecast: () => number
-
-  push: (time: number, value: number) => void
+    push: (time: number, value: number) => void
+  }
 }
+
+declare function MovingAverage(timespan: number): MovingAverage.IMovingAverage
+
 export = MovingAverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "moving-average",
-  "version": "1.0.0",
+  "name": "@vascosantos/moving-average",
+  "version": "1.1.0",
   "description": "Exponential Moving Average",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
TS compile fails with this modules with "An export assignment cannot be used in a module with other exported elements.ts(2309)".

This means that it needs to be a namespace export to get it working

Release on my namespace while it is not merged upstream